### PR TITLE
[BUGFIX] Sparse Retrieval 경로 문제 해결

### DIFF
--- a/retrieval/sparse/src/run_sparse_retrieval.py
+++ b/retrieval/sparse/src/run_sparse_retrieval.py
@@ -78,8 +78,9 @@ def main():
     logger.info(f"Total execution time: {total_time:.3f} s")
 
     # Append to CSV
+    sparse_path_name = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     append_to_csv(
-        f"../outputs/sparse_embedding_test_{args.embedding_method}.csv",
+        f"{sparse_path_name}/outputs/sparse_embedding_test_{args.embedding_method}.csv",
         args,
         total_time,
         evaluation_results,

--- a/retrieval/sparse/src/sparse_retrieval.py
+++ b/retrieval/sparse/src/sparse_retrieval.py
@@ -35,10 +35,11 @@ class SparseRetrieval:
         self.bm25 = None
 
     def get_sparse_embedding_tfidf(self) -> NoReturn:
+        sparse_path_name = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         pickle_name = f"{self.embedding_method}_sparse_embedding.bin"
         vectorizer_name = f"{self.embedding_method}.bin"
-        emb_path = os.path.join("../model", pickle_name)
-        vectorizer_path = os.path.join("../model", vectorizer_name)
+        emb_path = os.path.join(sparse_path_name, "model", pickle_name)
+        vectorizer_path = os.path.join(sparse_path_name, "model", vectorizer_name)
 
         if os.path.isfile(vectorizer_path) and os.path.isfile(emb_path):
             logger.info("Loading TF-IDF pickle files.")
@@ -63,8 +64,9 @@ class SparseRetrieval:
             logger.info("Embedding pickle saved.")
 
     def get_sparse_embedding_bm25(self) -> NoReturn:
+        sparse_path_name = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         vectorizer_name = f"{self.embedding_method}.bin"
-        vectorizer_path = os.path.join("../model", vectorizer_name)
+        vectorizer_path = os.path.join(sparse_path_name, "model", vectorizer_name)
 
         if os.path.isfile(vectorizer_path):  # bm25 does not use p_embedding
             logger.info("Loading BM25 pickle file.")

--- a/retrieval/sparse/utils/utils_sparse_retrieval.py
+++ b/retrieval/sparse/utils/utils_sparse_retrieval.py
@@ -17,7 +17,8 @@ def timer(name):
 
 
 def load_config(config_path: str):
-    full_config_path = "../config/" + config_path + ".json"
+    sparse_path_name = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    full_config_path = sparse_path_name + "/config/" + config_path + ".json"
     with open(full_config_path, "r") as f:
         config = json.load(f)
         config = Box(config)


### PR DESCRIPTION
## Overview
- 기존 코드에서 경로를 상대경로로 처리해, inference 시 제약이 발생했습니다.
- 이에 sparse 폴더 내의 모든 경로 처리 부분을 절대 경로 방식으로 변경했습니다.

## Change Log
- 다음 3가지 파일을 수정했습니다.
    - `src/sparse_retrieval.py`: `get_sparse_embedding_tfidf()` 및 `get_sparse_embedding_bm25()`에서 임베딩 파일 저장 경로 변경
    - `src/run_sparse_retrieval.py`: `append_to_csv()` 함수를 사용해 evaluate 된 결과의 저장 경로 변경
    - `utils/utils_sparse_retrieval.py`: `load_config()`에서 config 파일의 저장 경로 변경
- 절대경로 지정 시 `os.path.dirname(os.path.dirname(os.path.abspath(__file__)))` 코드를 활용했습니다.
```python
# 예시 - 기존
pickle_name = f"{self.embedding_method}_sparse_embedding.bin"

# 예시 - 변경 후
sparse_path_name = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
pickle_name = f"{self.embedding_method}_sparse_embedding.bin"
```

## To Reviewer
- BUG 이슈에서 제안해주신 config에 경로를 추가하는 방식도 고민했지만, 다음과 같은 두 가지 이유로 해당 방식을 채택했습니다.    
    - 첫째, 팀원마다 서버에 이 프로젝트 파일이 저장된 경로들이 약간씩 다름. 
        - 예: `/data/ephemeral/home/minji/retrieval/sparse/model/`에서 `minji` 등
        - 매 번 각자의 환경에 맞춰 config에서 파일 경로 수정하기 번거로울 것 
    - 둘째, `get_sparse_embedding` 함수들 뿐만 아니라 다른 경로들에도 공통적으로 수정이 필요해 보임
        - `run_sparse_retrieval.py` 및 `utils_sparse_retrieval.py` 등
- @LeeJeongHwi 확인부탁드려요:) 별다른 이상 없다고 하시면 바로 병합하겠습니다.

## Issue Tags
- Fixed: #18 
